### PR TITLE
Vault path templating fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Helm-Vault was created to provide a better way to manage secrets for Helm, with 
 ```
 $ helm vault enc values.yaml
 Input a value for /mariadb/db/password:
+Input a value for /externalDatabase/user:
 Input a value for /nextcloud/password:
 ```
 
@@ -193,7 +194,8 @@ The encrypt operation encrypts a values.yaml file and saves the encrypted values
 ```
 $ helm vault enc values.yaml
 Input a value for /nextcloud/password: asdf1
-Input a value for /mariadb/db/password: asdf2
+Input a value for /externalDatabase/user: asdf2
+Input a value for /mariadb/db/password: asdf3
 ```
 
 If you don't want to enter the secrets manually on stdin, you can pass a file containing the secrets. Copy `values.yaml` to `values.yaml.dec` and edit the file, replacing "changeme" (the deliminator) with the secret value. Then you can save the secret to vault by running: 
@@ -257,6 +259,23 @@ The operation will delete all decrypted files in a directory:
 ```
 $ helm vault clean
 ```
+
+### vault path templating
+
+It is possible to setup vault's path inside helm chart like this
+
+```
+key1: VAULT:helm1/test/key1
+key2: VAULT:/helm2/test/key2
+```
+This mean that key1 will be storing into base_path/helm1/test/key1 and key2 into /helm2/test/key2 . Where is helm2 is root path enabled via secrets enable. For example:
+
+```
+vault secrets enable  -path=helm2 kv-v2
+```
+
+To override default value of template path pattern use **SECRET_TEMPLATE** variable. By default this value is VAULT: . This is mean that all keys with values like VAULT:something will be stored inside vault.
+
 
 ### Wrapper Examples
 

--- a/src/vault.py
+++ b/src/vault.py
@@ -252,10 +252,7 @@ class Vault:
             if self.args.verbose is True:
                 print(f"Using KV Version: {self.kvversion}")
             try:
-                if mount_point is not None:
-                    self.client.write(_path, value=value, mount_point = mount_point)
-                else:
-                    self.client.write(_path, value=value)
+                self.client.write(_path, value=value, mount_point = mount_point)
                 if self.args.verbose is True:
                     print(f"Wrote {value} to: {_path}")
             except AttributeError:
@@ -267,17 +264,11 @@ class Vault:
             if self.args.verbose is True:
                 print(f"Using KV Version: {self.kvversion}")
             try:
-                if mount_point is not None:
-                    self.client.secrets.kv.v2.create_or_update_secret(
-                        path=_path,
-                        secret=dict(value=value),
-                        mount_point = mount_point,
-                    )
-                else:
-                    self.client.secrets.kv.v2.create_or_update_secret(
-                        path=_path,
-                        secret=dict(value=value),
-                    )                    
+                self.client.secrets.kv.v2.create_or_update_secret(
+                    path=_path,
+                    secret=dict(value=value),
+                    mount_point = mount_point,
+                )
                 if self.args.verbose is True:
                     print(f"Wrote {value} to: {_path}")
             except AttributeError:
@@ -322,15 +313,10 @@ class Vault:
             if self.args.verbose is True:
                 print(f"Using KV Version: {self.kvversion}")
             try:
-                if mount_point is not None:
-                    value = self.client.secrets.kv.v2.read_secret_version(
-                        path=_path,
-                        mount_point=mount_point,
-                    )
-                else:
-                     value = self.client.secrets.kv.v2.read_secret_version(
-                        path=_path,
-                    )                   
+                value = self.client.secrets.kv.v2.read_secret_version(
+                    path=_path,
+                    mount_point=mount_point,
+                )
                 value = value.get("data", {}).get("data", {}).get("value")
                 if self.args.verbose is True:
                     print(f"Got {value} from: {_path}")
@@ -391,7 +377,7 @@ def dict_walker(pattern, data, args, envs, secret_data, path=None):
     action = args.action
     if isinstance(data, dict):
         for key, value in data.items():
-            if value == pattern or str(value).startswith(envs[VAULT_TEMPLATE_POSITION]):
+            if value == pattern or value.startswith(envs[VAULT_TEMPLATE_POSITION]):
                 if value.startswith(envs[VAULT_TEMPLATE_POSITION]):
                     _full_path = value[len(envs[VAULT_TEMPLATE_POSITION]):]
                 else:

--- a/src/vault.py
+++ b/src/vault.py
@@ -13,9 +13,6 @@ import platform
 import subprocess
 check_call = subprocess.check_call
 
-VAULT_PATH_POSITION = 0 
-VAULT_TEMPLATE_POSITION = 4
-
 if sys.version_info[:2] < (3, 7):
     raise Exception("Python 3.7 or a more recent version is required.")
 
@@ -38,7 +35,6 @@ def parse_args(args):
     encrypt.add_argument("yaml_file", type=str, help="The YAML file to be worked on")
     encrypt.add_argument("-d", "--deliminator", type=str, help="The secret deliminator used when parsing. Default: \"changeme\"")
     encrypt.add_argument("-vp", "--vaultpath", type=str, help="The Vault Path (secret mount location in Vault) Default: \"secret/helm\"")
-    encrypt.add_argument("-vt", "--vaulttemplate", type=str, help="Substring with path to vault key instead of deliminator. Default: \"VAULT:\"")
     encrypt.add_argument("-kv", "--kvversion", choices=['v1', 'v2'], default='v1', type=str, help="The KV Version (v1, v2) Default: \"v1\"")
     encrypt.add_argument("-s", "--secret-file", type=str, help="File containing the secret for input. Must end in .yaml.dec")
     encrypt.add_argument("-v", "--verbose", help="Verbose logs", const=True, nargs="?")
@@ -47,7 +43,6 @@ def parse_args(args):
     decrypt = subparsers.add_parser("dec", help="Parse a YAML file and retrieve values from Vault")
     decrypt.add_argument("yaml_file", type=str, help="The YAML file to be worked on")
     decrypt.add_argument("-d", "--deliminator", type=str, help="The secret deliminator used when parsing. Default: \"changeme\"")
-    decrypt.add_argument("-vt", "--vaulttemplate", type=str, help="Substring with path to vault key instead of deliminator. Default: \"VAULT:\"")
     decrypt.add_argument("-vp", "--vaultpath", type=str, help="The Vault Path (secret mount location in Vault). Default: \"secret/helm\"")
     decrypt.add_argument("-kv", "--kvversion", choices=['v1', 'v2'], default='v1', type=str, help="The KV Version (v1, v2) Default: \"v1\"")
     decrypt.add_argument("-v", "--verbose", help="Verbose logs", const=True, nargs="?")
@@ -61,7 +56,6 @@ def parse_args(args):
     view = subparsers.add_parser("view", help="View decrypted YAML file")
     view.add_argument("yaml_file", type=str, help="The YAML file to be worked on")
     view.add_argument("-d", "--deliminator", type=str, help="The secret deliminator used when parsing. Default: \"changeme\"")
-    view.add_argument("-vt", "--vaulttemplate", type=str, help="Substring with path to vault key instead of deliminator. Default: \"VAULT:\"")
     view.add_argument("-vp", "--vaultpath", type=str, help="The Vault Path (secret mount location in Vault). Default: \"secret/helm\"")
     view.add_argument("-kv", "--kvversion", choices=['v1', 'v2'], default='v1', type=str, help="The KV Version (v1, v2) Default: \"v1\"")
     view.add_argument("-v", "--verbose", help="Verbose logs", const=True, nargs="?")
@@ -70,7 +64,6 @@ def parse_args(args):
     edit = subparsers.add_parser("edit", help="Edit decrypted YAML file. DOES NOT CLEAN UP AUTOMATICALLY.")
     edit.add_argument("yaml_file", type=str, help="The YAML file to be worked on")
     edit.add_argument("-d", "--deliminator", type=str, help="The secret deliminator used when parsing. Default: \"changeme\"")
-    edit.add_argument("-vt", "--vaulttemplate", type=str, help="Substring with path to vault key instead of deliminator. Default: \"VAULT:\"")
     edit.add_argument("-vp", "--vaultpath", type=str, help="The Vault Path (secret mount location in Vault). Default: \"secret/helm\"")
     edit.add_argument("-kv", "--kvversion", choices=['v1', 'v2'], default='v1', type=str, help="The KV Version (v1, v2) Default: \"v1\"")
     edit.add_argument("-e", "--editor", help="Editor name. Default: (Linux/MacOS) \"vi\" (Windows) \"notepad\"", const=True, nargs="?")
@@ -80,7 +73,6 @@ def parse_args(args):
     install = subparsers.add_parser("install", help="Wrapper that decrypts YAML files before running helm install")
     install.add_argument("-f", "--values", type=str, dest="yaml_file", help="The encrypted YAML file to decrypt on the fly")
     install.add_argument("-d", "--deliminator", type=str, help="The secret deliminator used when parsing. Default: \"changeme\"")
-    install.add_argument("-vt", "--vaulttemplate", type=str, help="Substring with path to vault key instead of deliminator. Default: \"VAULT:\"")
     install.add_argument("-vp", "--vaultpath", type=str, help="The Vault Path (secret mount location in Vault). Default: \"secret/helm\"")
     install.add_argument("-kv", "--kvversion", choices=['v1', 'v2'], default='v1', type=str, help="The KV Version (v1, v2) Default: \"v1\"")
     install.add_argument("-v", "--verbose", help="Verbose logs", const=True, nargs="?")
@@ -89,7 +81,6 @@ def parse_args(args):
     template = subparsers.add_parser("template", help="Wrapper that decrypts YAML files before running helm install")
     template.add_argument("-f", "--values", type=str, dest="yaml_file", help="The encrypted YAML file to decrypt on the fly")
     template.add_argument("-d", "--deliminator", type=str, help="The secret deliminator used when parsing. Default: \"changeme\"")
-    template.add_argument("-vt", "--vaulttemplate", type=str, help="Substring with path to vault key instead of deliminator. Default: \"VAULT:\"")
     template.add_argument("-vp", "--vaultpath", type=str, help="The Vault Path (secret mount location in Vault). Default: \"secret/helm\"")
     template.add_argument("-kv", "--kvversion", choices=['v1', 'v2'], default='v1', type=str, help="The KV Version (v1, v2) Default: \"v1\"")
     template.add_argument("-v", "--verbose", help="Verbose logs", const=True, nargs="?")
@@ -98,7 +89,6 @@ def parse_args(args):
     upgrade = subparsers.add_parser("upgrade", help="Wrapper that decrypts YAML files before running helm install")
     upgrade.add_argument("-f", "--values", type=str, dest="yaml_file", help="The encrypted YAML file to decrypt on the fly")
     upgrade.add_argument("-d", "--deliminator", type=str, help="The secret deliminator used when parsing. Default: \"changeme\"")
-    upgrade.add_argument("-vt", "--vaulttemplate", type=str, help="Substring with path to vault key instead of deliminator. Default: \"VAULT:\"")
     upgrade.add_argument("-vp", "--vaultpath", type=str, help="The Vault Path (secret mount location in Vault). Default: \"secret/helm\"")
     upgrade.add_argument("-kv", "--kvversion", choices=['v1', 'v2'], default='v1', type=str, help="The KV Version (v1, v2) Default: \"v1\"")
     upgrade.add_argument("-v", "--verbose", help="Verbose logs", const=True, nargs="?")
@@ -107,7 +97,6 @@ def parse_args(args):
     lint = subparsers.add_parser("lint", help="Wrapper that decrypts YAML files before running helm install")
     lint.add_argument("-f", "--values", type=str, dest="yaml_file", help="The encrypted YAML file to decrypt on the fly")
     lint.add_argument("-d", "--deliminator", type=str, help="The secret deliminator used when parsing. Default: \"changeme\"")
-    lint.add_argument("-vt", "--vaulttemplate", type=str, help="Substring with path to vault key instead of deliminator. Default: \"VAULT:\"")
     lint.add_argument("-vp", "--vaultpath", type=str, help="The Vault Path (secret mount location in Vault). Default: \"secret/helm\"")
     lint.add_argument("-kv", "--kvversion", choices=['v1', 'v2'], default='v1', type=str, help="The KV Version (v1, v2) Default: \"v1\"")
     lint.add_argument("-v", "--verbose", help="Verbose logs", const=True, nargs="?")
@@ -116,7 +105,6 @@ def parse_args(args):
     diff = subparsers.add_parser("diff", help="Wrapper that decrypts YAML files before running helm diff")
     diff.add_argument("-f", "--values", type=str, dest="yaml_file", help="The encrypted YAML file to decrypt on the fly")
     diff.add_argument("-d", "--deliminator", type=str, help="The secret deliminator used when parsing. Default: \"changeme\"")
-    diff.add_argument("-vt", "--vaulttemplate", type=str, help="Substring with path to vault key instead of deliminator. Default: \"VAULT:\"")
     diff.add_argument("-vp", "--vaultpath", type=str, help="The Vault Path (secret mount location in Vault). Default: \"secret/helm\"")
     diff.add_argument("-kv", "--kvversion", choices=['v1', 'v2'], default='v1', type=str, help="The KV Version (v1, v2) Default: \"v1\"")
     diff.add_argument("-v", "--verbose", help="Verbose logs", const=True, nargs="?")
@@ -166,19 +154,6 @@ class Envs:
                 if self.args.verbose is True:
                     print("The default deliminator is: " + deliminator)
 
-        if "SECRET_TEMPLATE" in os.environ:
-            vault_template=os.environ["SECRET_TEMPLATE"]
-            if self.args.verbose is True:
-                print("The env vault template is: " + vault_template)
-        else:
-            if self.args.vaulttemplate:
-                vault_template = self.args.vaulttemplate
-                if self.args.verbose is True:
-                    print("The vault template is: " + vault_template)
-            else:
-                vault_template = "VAULT:"
-                if self.args.verbose is True:
-                    print("The default vault template is: " + vault_template)
         if "EDITOR" in os.environ:
             editor=os.environ["EDITOR"]
             if self.args.verbose is True:
@@ -214,7 +189,7 @@ class Envs:
                 if self.args.verbose is True:
                     print("The default kvversion is: " + kvversion)
 
-        return secret_mount, deliminator, editor, kvversion, vault_template
+        return secret_mount, deliminator, editor, kvversion
 
 class Vault:
     def __init__(self, args, envs):
@@ -233,28 +208,15 @@ class Vault:
         except Exception as ex:
             print(f"ERROR: {ex}")
 
-    def vault_write(self, value, path, key, full_path=None):
-        # Use path from template if presents
-        if full_path is not None:
-            _path = full_path
-            if _path.startswith('/'):
-                mount_point = _path.split('/')[1]
-                _path = '/'.join(_path.split('/')[2:])
-            else:
-                mount_point = self.envs[VAULT_PATH_POSITION].split('/')[0]
-        else:
-            mount_point = None
-            _path = f"{self.envs[0]}/{self.folder}{path}/{key}"
-
-
+    def vault_write(self, value, path, key):
         # Write to vault, using the correct Vault KV version
         if self.kvversion == "v1":
             if self.args.verbose is True:
                 print(f"Using KV Version: {self.kvversion}")
             try:
-                self.client.write(_path, value=value, mount_point = mount_point)
+                self.client.write(f"{self.envs[0]}/{self.folder}{path}/{key}", value=value)
                 if self.args.verbose is True:
-                    print(f"Wrote {value} to: {_path}")
+                    print(f"Wrote {value} to: {self.envs[0]}/{self.folder}{path}/{key}")
             except AttributeError:
                 print("Vault not configured correctly, check VAULT_ADDR and VAULT_TOKEN env variables.")
             except Exception as ex:
@@ -265,12 +227,11 @@ class Vault:
                 print(f"Using KV Version: {self.kvversion}")
             try:
                 self.client.secrets.kv.v2.create_or_update_secret(
-                    path=_path,
+                    path=f"{self.envs[0]}/{self.folder}{path}/{key}",
                     secret=dict(value=value),
-                    mount_point = mount_point,
                 )
                 if self.args.verbose is True:
-                    print(f"Wrote {value} to: {_path}")
+                    print(f"Wrote {value} to: {self.envs[0]}/{self.folder}{path}/{key}")
             except AttributeError:
                 print("Vault not configured correctly, check VAULT_ADDR and VAULT_TOKEN env variables.")
             except Exception as ex:
@@ -280,30 +241,18 @@ class Vault:
             print("Wrong KV Version specified, either v1 or v2")
 
 
-    def vault_read(self, value, path, key, full_path=None):
-        # Use path from template if presents
-        if full_path is not None:
-            _path = full_path
-            if _path.startswith('/'):
-                mount_point = _path.split('/')[1]
-                _path = '/'.join(_path.split('/')[2:])
-            else:
-                mount_point = self.envs[VAULT_PATH_POSITION].split('/')[0]
-        else:
-            mount_point = None
-            _path = f"{self.envs[0]}/{self.folder}{path}/{key}"
-
+    def vault_read(self, value, path, key):
         # Read from Vault, using the correct Vault KV version
         if self.kvversion == "v1":
             if self.args.verbose is True:
                 print(f"Using KV Version: {self.kvversion}")
             try:
-                value = self.client.read(_path)
+                value = self.client.read(f"{self.envs[0]}/{self.folder}{path}/{key}")
                 if self.args.verbose is True:
-                    print(f"Got {value} from: {_path}")
+                    print(f"Got {value} from: {self.envs[0]}/{self.folder}{path}/{key}")
                 return value.get("data", {}).get("value")
-            except AttributeError as ex:
-                print(f"Vault not configured correctly, check VAULT_ADDR and VAULT_TOKEN env variables. {ex}")
+            except AttributeError:
+                print("Vault not configured correctly, check VAULT_ADDR and VAULT_TOKEN env variables.")
             except Exception as ex:
                 print(f"Error: {ex}")
             except Exception as ex:
@@ -314,12 +263,11 @@ class Vault:
                 print(f"Using KV Version: {self.kvversion}")
             try:
                 value = self.client.secrets.kv.v2.read_secret_version(
-                    path=_path,
-                    mount_point=mount_point,
+                    path=f"{self.envs[0]}/{self.folder}{path}/{key}",
                 )
                 value = value.get("data", {}).get("data", {}).get("value")
                 if self.args.verbose is True:
-                    print(f"Got {value} from: {_path}")
+                    print(f"Got {value} from: {self.envs[0]}/{self.folder}{path}/{key}")
                 return value
             except AttributeError:
                 print("Vault not configured correctly, check VAULT_ADDR and VAULT_TOKEN env variables.")
@@ -377,21 +325,17 @@ def dict_walker(pattern, data, args, envs, secret_data, path=None):
     action = args.action
     if isinstance(data, dict):
         for key, value in data.items():
-            if value == pattern or value.startswith(envs[VAULT_TEMPLATE_POSITION]):
-                if value.startswith(envs[VAULT_TEMPLATE_POSITION]):
-                    _full_path = value[len(envs[VAULT_TEMPLATE_POSITION]):]
-                else:
-                    _full_path = None
+            if value == pattern:
                 if action == "enc":
                     if secret_data:
                         data[key] = value_from_path(secret_data, f"{path}/{key}")
                     else:
                         data[key] = input(f"Input a value for {path}/{key}: ")
                     vault = Vault(args, envs)
-                    vault.vault_write(data[key], path, key, _full_path)
+                    vault.vault_write(data[key], path, key)
                 elif (action == "dec") or (action == "view") or (action == "edit") or (action == "install") or (action == "template") or (action == "upgrade") or (action == "lint") or (action == "diff"):
                     vault = Vault(args, envs)
-                    vault = vault.vault_read(value, path, key, _full_path)
+                    vault = vault.vault_read(value, path, key)
                     value = vault
                     data[key] = value
             for res in dict_walker(pattern, value, args, envs, secret_data, path=f"{path}/{key}"):

--- a/tests/test.yaml
+++ b/tests/test.yaml
@@ -42,7 +42,7 @@ externalDatabase:
   host:
 
   ## Database user
-  user: nextcloud
+  user: VAULT:/secret/testdata/user
 
   ## Database password
   password:

--- a/tests/test.yaml.dec
+++ b/tests/test.yaml.dec
@@ -24,7 +24,7 @@ ingress:
 nextcloud:
   host: nextcloud.corp.justin-tech.com
   username: admin
-  password:
+  password: nextpass
 
 
 internalDatabase:
@@ -60,7 +60,7 @@ mariadb:
   db:
     name: nextcloud
     user: nextcloud
-    password:
+    password: mariapass
 
   ## Enable persistence using Persistent Volume Claims
   ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/

--- a/tests/test.yaml.dec
+++ b/tests/test.yaml.dec
@@ -60,7 +60,7 @@ mariadb:
   db:
     name: nextcloud
     user: nextcloud
-    password: mariapass
+    password:
 
   ## Enable persistence using Persistent Volume Claims
   ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/

--- a/tests/test_vault.py
+++ b/tests/test_vault.py
@@ -19,7 +19,7 @@ import subprocess
 
 def test_load_yaml():
 
-    data_test = ordereddict([('image', ordereddict([('repository', 'nextcloud'), ('tag', '15.0.2-apache'), ('pullPolicy', 'IfNotPresent')])), ('nameOverride', ''), ('fullnameOverride', ''), ('replicaCount', 1), ('ingress', ordereddict([('enabled', True), ('annotations', ordereddict())])), ('nextcloud', ordereddict([('host', 'nextcloud.corp.justin-tech.com'), ('username', 'admin'), ('password', 'changeme')])), ('internalDatabase', ordereddict([('enabled', True), ('name', 'nextcloud')])), ('externalDatabase', ordereddict([('enabled', False), ('host', None), ('user', 'nextcloud'), ('password', None), ('database', 'nextcloud')])), ('mariadb', ordereddict([('enabled', True), ('db', ordereddict([('name', 'nextcloud'), ('user', 'nextcloud'), ('password', 'changeme')])), ('persistence', ordereddict([('enabled', True), ('storageClass', 'nfs-client'), ('accessMode', 'ReadWriteOnce'), ('size', '8Gi')]))])), ('service', ordereddict([('type', 'ClusterIP'), ('port', 8080), ('loadBalancerIP', 'nil')])), ('persistence', ordereddict([('enabled', True), ('storageClass', 'nfs-client'), ('accessMode', 'ReadWriteOnce'), ('size', '8Gi')])), ('resources', ordereddict()), ('nodeSelector', ordereddict()), ('tolerations', []), ('affinity', ordereddict())])
+    data_test = ordereddict([('image', ordereddict([('repository', 'nextcloud'), ('tag', '15.0.2-apache'), ('pullPolicy', 'IfNotPresent')])), ('nameOverride', ''), ('fullnameOverride', ''), ('replicaCount', 1), ('ingress', ordereddict([('enabled', True), ('annotations', ordereddict())])), ('nextcloud', ordereddict([('host', 'nextcloud.corp.justin-tech.com'), ('username', 'admin'), ('password', 'changeme')])), ('internalDatabase', ordereddict([('enabled', True), ('name', 'nextcloud')])), ('externalDatabase', ordereddict([('enabled', False), ('host', None), ('user', 'VAULT:/secret/testdata/user'), ('password', None), ('database', 'nextcloud')])), ('mariadb', ordereddict([('enabled', True), ('db', ordereddict([('name', 'nextcloud'), ('user', 'nextcloud'), ('password', 'changeme')])), ('persistence', ordereddict([('enabled', True), ('storageClass', 'nfs-client'), ('accessMode', 'ReadWriteOnce'), ('size', '8Gi')]))])), ('service', ordereddict([('type', 'ClusterIP'), ('port', 8080), ('loadBalancerIP', 'nil')])), ('persistence', ordereddict([('enabled', True), ('storageClass', 'nfs-client'), ('accessMode', 'ReadWriteOnce'), ('size', '8Gi')])), ('resources', ordereddict()), ('nodeSelector', ordereddict()), ('tolerations', []), ('affinity', ordereddict())])
 
     yaml_file = "./tests/test.yaml"
     data = vault.load_yaml(yaml_file)
@@ -43,7 +43,7 @@ def filecheckfunc():
 
 def test_enc():
     os.environ["KVVERSION"] = "v2"
-    input_values = ["adfs1", "adfs2"]
+    input_values = ["adfs1", "adfs2", "adfs3"]
     output = []
 
     def mock_input(s):
@@ -56,6 +56,7 @@ def test_enc():
 
     assert output == [
         'Input a value for /nextcloud/password: ',
+        'Input a value for /externalDatabase/user: ',
         'Input a value for /mariadb/db/password: ',
     ]
 


### PR DESCRIPTION
# Pull Request Template

## Description

Recommit for reverted PR https://github.com/Just-Insane/helm-vault/pull/6

Allow to set vault paths inside charts instead of using autogenerated one. Now it is possible to use not only deliminators and vaultpath as path generator but --vaulttemplate pattern for path setting. By default  vaut template is VAULT:

How it works.

key1: VAULT:helm1/test/key1
key2: VAULT:/helm2/test/key2

key1 - will be storing in base_path/helm1/test/key1 (by default secrets/helm1/key1)
key2 - will be storing in /helm2/test/key2 . Where is helm2 - secrets base added like this: **vault secrets enable  -path=helm2 kv-v2**

This feature does not brake deliminators support but only allow new way for key path definition.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [+ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

**Test Configuration**:
v3.2.4

* Python Version:
3.7.3

* Vault Version:
1.4.2

## Checklist:

- [ +] My code follows the style guidelines of this project
- [ +] I have performed a self-review of my own code
- [ +] I have commented my code, particularly in hard-to-understand areas
- [ +] I have made corresponding changes to the documentation
- [ +] My changes generate no new warnings
- [ +] I have added tests that prove my fix is effective or that my feature works
- [ +] New and existing unit tests pass locally with my changes
- [ +] Any dependent changes have been merged and published in downstream modules

## Mentions:

@Just-Insane
