### PR TITLE
Change `yaml.load` to `yaml.load_all`

### DIFF
--- a/src/vault.py
+++ b/src/vault.py
@@ -346,6 +346,7 @@ def load_yaml(yaml_file):
     yaml = ruamel.yaml.YAML()
     yaml.preserve_quotes = True
     with open(yaml_file) as filepath:
+        # Use yaml.load_all to be able to load multi-yaml files
         data = list(yaml.load_all(filepath))
         return data
 

--- a/src/vault.py
+++ b/src/vault.py
@@ -346,7 +346,7 @@ def load_yaml(yaml_file):
     yaml = ruamel.yaml.YAML()
     yaml.preserve_quotes = True
     with open(yaml_file) as filepath:
-        data = yaml.load(filepath)
+        data = list(yaml.load_all(filepath))
         return data
 
 def cleanup(args):


### PR DESCRIPTION
## Description

This PR addresses an issue when trying to load yaml files that are seperated with `----` lines by using `yaml.load_all`. Currently it will break the plugin if you try to load a full helm manifest that is already made, but still needs to be decrypted. This change will allow you to pass a fully created manifest file to the helm vault plugin to be decrypted/encrypted

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

I changed line:
https://github.com/Just-Insane/helm-vault/blob/538f41c49a18dd80b4c6521e3f57fd3e2552e501/src/vault.py#L349

to:
`data = list(yaml.load_all(filepath))`

then ran encrypt/decrypt tests on traditional `values.yaml` files, as well as full manifests, and both worked flawlessly.
 
**Test Configuration**:
* Python Version: Python 3.8.5
* Vault Version: 1.2.2

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Mentions:

@Just-Insane
