### PR TITLE
first pass at enc and dec

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,8 +279,9 @@ Each of these commands have their own help, referenced by `helm vault {enc,dec,c
 |`-v`, `--verbose`|Verbose output||`enc`, `dec`, `clean`, `view`, `edit`, `install`, `template`, `upgrade`, `lint`, `diff`|
 |`-s`, `--secret-file`|File containing secrets for input, rather than using stdin, must end in `.yaml.dec`||`enc`|
 |`-f`, `--file`|The specific YAML file to be deleted, without `.dec`||`clean`|
-|`-e`, `--editor`|Editor name|Windows: `notepad`, macOS/Linux: `vi`|`edit`|
+|`-ed`, `--editor`|Editor name|Windows: `notepad`, macOS/Linux: `vi`|`edit`|
 |`-f`, `--values`|The encrypted YAML file to decrypt on the fly||`install`, `template`, `upgrade`, `lint`, `diff`|
+|`-e`, `--environment`|Environment that secrets should be stored under||`enc`, `dec`, `clean`, `install`|
 
 
 ### Usage examples
@@ -291,9 +292,9 @@ The encrypt operation encrypts a values.yaml file and saves the encrypted values
 
 ```
 $ helm vault enc values.yaml
-Input a value for /nextcloud/password: asdf1
-Input a value for /externalDatabase/user: asdf2
-Input a value for /mariadb/db/password: asdf3
+Input a value for nextcloud.password: asdf1
+Input a value for externalDatabase.user: asdf2
+Input a value for .mariadb.db.password: asdf3
 ```
 
 If you don't want to enter the secrets manually on stdin, you can pass a file containing the secrets. Copy `values.yaml` to `values.yaml.dec` and edit the file, replacing "changeme" (the deliminator) with the secret value. Then you can save the secret to vault by running: 
@@ -303,6 +304,15 @@ $ helm vault enc values.yaml -s values.yaml.dec
 ```
 
 By default the name of the secret file has to end in `.yaml.dec` so you can add this extension to gitignore to prevent committing a secret to your git repo.
+
+In addition, you can namespace your secrets to a desired environment by using the `-e` flag.
+
+```
+helm vault enc values.yaml -e prod
+Input a value for nextcloud.password: asdf1
+Input a value for externalDatabase.user: asdf2
+Input a value for mariadb.db.password: asdf3
+```
 
 #### Decrypt
 
@@ -330,6 +340,18 @@ parameters
     password: asdf2
 ...
 ```
+
+If leveraging environment specific secrets, you can decrypt the desired environment by specifying with the `-e` flag.
+
+Doing so will result in a decrypted file that is stored as `my_file.yaml.{environment}.dec`
+
+For example
+
+```
+$ helm vault dec values.yaml -e prod
+```
+
+Will result in your production environment secrets being dumped into a file named `values.yaml.prod.dec`
 
 #### View
 

--- a/src/vault.py
+++ b/src/vault.py
@@ -58,6 +58,7 @@ def parse_args(args):
     clean = subparsers.add_parser("clean", help="Remove decrypted files (in the current directory)")
     clean.add_argument("-f", "--file", type=str, help="The specific YAML file to be deleted, without .dec", dest="yaml_file")
     clean.add_argument("-v", "--verbose", help="Verbose logs", const=True, nargs="?")
+    clean.add_argument("-e", "--environment", type=str, help="Decoded environment to clean")
 
     # View Help
     view = subparsers.add_parser("view", help="View decrypted YAML file")
@@ -354,8 +355,9 @@ def load_yaml(yaml_file):
 def cleanup(args):
     # Cleanup decrypted files
     yaml_file = args.yaml_file
+    environment = f".{args.environment}" if args.environment is not None else ""
     try:
-        os.remove(f"{yaml_file}.dec")  # TODO per env? or blanket clean yaml_file.*.dec
+        os.remove(f"{yaml_file}{environment}.dec")
         if args.verbose is True:
             print(f"Deleted {yaml_file}.dec")
             sys.exit()

--- a/src/vault.py
+++ b/src/vault.py
@@ -42,6 +42,7 @@ def parse_args(args):
     encrypt.add_argument("-kv", "--kvversion", choices=['v1', 'v2'], default='v1', type=str, help="The KV Version (v1, v2) Default: \"v1\"")
     encrypt.add_argument("-s", "--secret-file", type=str, help="File containing the secret for input. Must end in .yaml.dec")
     encrypt.add_argument("-v", "--verbose", help="Verbose logs", const=True, nargs="?")
+    encrypt.add_argument("-e", "--environment", type=str, help="Allows for secrets to be encoded on a per environment basis")
 
     # Decrypt help
     decrypt = subparsers.add_parser("dec", help="Parse a YAML file and retrieve values from Vault")
@@ -51,6 +52,7 @@ def parse_args(args):
     decrypt.add_argument("-vp", "--vaultpath", type=str, help="The Vault Path (secret mount location in Vault). Default: \"secret/helm\"")
     decrypt.add_argument("-kv", "--kvversion", choices=['v1', 'v2'], default='v1', type=str, help="The KV Version (v1, v2) Default: \"v1\"")
     decrypt.add_argument("-v", "--verbose", help="Verbose logs", const=True, nargs="?")
+    decrypt.add_argument("-e", "--environment", type=str, help="Allows for secrets to be decoded on a per environment basis")
 
     # Clean help
     clean = subparsers.add_parser("clean", help="Remove decrypted files (in the current directory)")
@@ -385,7 +387,8 @@ def value_from_path(secret_data, path):
 
 def dict_walker(pattern, data, args, envs, secret_data, path=None):
     # Walk through the loaded dicts looking for the values we want
-    path = path if path is not None else ""
+    environment = f"/{args.environment}" if args.environment is not None else ""
+    path = path if path is not None else environment
     action = args.action
     if isinstance(data, dict):
         for key, value in data.items():
@@ -440,6 +443,7 @@ def main(argv=None):
     yaml.preserve_quotes = True
     secret_data = load_secret(args) if args.action == 'enc' else None
 
+    print(envs)
     for path, key, value in dict_walker(envs[1], data, args, envs, secret_data):
         print("Done")
 

--- a/src/vault.py
+++ b/src/vault.py
@@ -443,7 +443,6 @@ def main(argv=None):
     yaml.preserve_quotes = True
     secret_data = load_secret(args) if args.action == 'enc' else None
 
-    print(envs)
     for path, key, value in dict_walker(envs[1], data, args, envs, secret_data):
         print("Done")
 

--- a/src/vault.py
+++ b/src/vault.py
@@ -76,7 +76,7 @@ def parse_args(args):
     edit.add_argument("-vt", "--vaulttemplate", type=str, help="Substring with path to vault key instead of deliminator. Default: \"VAULT:\"")
     edit.add_argument("-vp", "--vaultpath", type=str, help="The Vault Path (secret mount location in Vault). Default: \"secret/helm\"")
     edit.add_argument("-kv", "--kvversion", choices=['v1', 'v2'], default='v1', type=str, help="The KV Version (v1, v2) Default: \"v1\"")
-    edit.add_argument("-e", "--editor", help="Editor name. Default: (Linux/MacOS) \"vi\" (Windows) \"notepad\"", const=True, nargs="?")
+    edit.add_argument("-ed", "--editor", help="Editor name. Default: (Linux/MacOS) \"vi\" (Windows) \"notepad\"", const=True, nargs="?")
     edit.add_argument("-v", "--verbose", help="Verbose logs", const=True, nargs="?")
 
     # Install Help

--- a/src/vault.py
+++ b/src/vault.py
@@ -402,10 +402,12 @@ def dict_walker(pattern, data, args, envs, secret_data, path=None):
                 else:
                     _full_path = None
                 if action == "enc":
+                    path_sans_env = path.replace(environment, '')
                     if secret_data:
-                        data[key] = value_from_path(secret_data, f"{path}/{key}")
+                        data[key] = value_from_path(secret_data, f"{path_sans_env}/{key}")
                     else:
-                        data[key] = input(f"Input a value for {path}/{key}: ")
+                        path_to_property_syntax = path_sans_env.replace("/", ".")[1:]
+                        data[key] = input(f"Input a value for {path_to_property_syntax}.{key}: ")
                     vault = Vault(args, envs)
                     vault.vault_write(data[key], path, key, _full_path)
                 elif (action == "dec") or (action == "view") or (action == "edit") or (action == "install") or (action == "template") or (action == "upgrade") or (action == "lint") or (action == "diff"):

--- a/tests/test.yaml
+++ b/tests/test.yaml
@@ -45,7 +45,7 @@ externalDatabase:
   user: VAULT:/secret/testdata/user
 
   ## Database password
-  password:
+  password: VAULT:/secret/{environment}/testdata/password
 
   ## Database name
   database: nextcloud

--- a/tests/test.yaml.dec
+++ b/tests/test.yaml.dec
@@ -24,7 +24,7 @@ ingress:
 nextcloud:
   host: nextcloud.corp.justin-tech.com
   username: admin
-  password: nextpass
+  password:
 
 
 internalDatabase:
@@ -42,7 +42,7 @@ externalDatabase:
   host:
 
   ## Database user
-  user: nextcloud
+  user:
 
   ## Database password
   password:
@@ -60,7 +60,7 @@ mariadb:
   db:
     name: nextcloud
     user: nextcloud
-    password: mariapass
+    password:
 
   ## Enable persistence using Persistent Volume Claims
   ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/

--- a/tests/test.yaml.dec
+++ b/tests/test.yaml.dec
@@ -39,13 +39,13 @@ externalDatabase:
   enabled: false
 
   ## Database host
-  host:
+  host: nextpass
 
   ## Database user
-  user:
+  user: nextcloud
 
   ## Database password
-  password:
+  password: mariapass
 
   ## Database name
   database: nextcloud

--- a/tests/test.yaml.dec
+++ b/tests/test.yaml.dec
@@ -24,7 +24,7 @@ ingress:
 nextcloud:
   host: nextcloud.corp.justin-tech.com
   username: admin
-  password:
+  password: nextpass
 
 
 internalDatabase:
@@ -39,13 +39,13 @@ externalDatabase:
   enabled: false
 
   ## Database host
-  host: nextpass
+  host:
 
   ## Database user
   user: nextcloud
 
   ## Database password
-  password: mariapass
+  password:
 
   ## Database name
   database: nextcloud
@@ -60,7 +60,7 @@ mariadb:
   db:
     name: nextcloud
     user: nextcloud
-    password:
+    password: mariapass
 
   ## Enable persistence using Persistent Volume Claims
   ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/

--- a/tests/test_vault.py
+++ b/tests/test_vault.py
@@ -13,10 +13,10 @@ import src.vault as vault
 
 def test_load_yaml():
 
-    data_test = ordereddict([('image', ordereddict([('repository', 'nextcloud'), ('tag', '15.0.2-apache'), ('pullPolicy', 'IfNotPresent')])), ('nameOverride', ''), ('fullnameOverride', ''), ('replicaCount', 1), ('ingress', ordereddict([('enabled', True), ('annotations', ordereddict())])), ('nextcloud', ordereddict([('host', 'nextcloud.corp.justin-tech.com'), ('username', 'admin'), ('password', 'changeme')])), ('internalDatabase', ordereddict([('enabled', True), ('name', 'nextcloud')])), ('externalDatabase', ordereddict([('enabled', False), ('host', None), ('user', 'VAULT:/secret/testdata/user'), ('password', None), ('database', 'nextcloud')])), ('mariadb', ordereddict([('enabled', True), ('db', ordereddict([('name', 'nextcloud'), ('user', 'nextcloud'), ('password', 'changeme')])), ('persistence', ordereddict([('enabled', True), ('storageClass', 'nfs-client'), ('accessMode', 'ReadWriteOnce'), ('size', '8Gi')]))])), ('service', ordereddict([('type', 'ClusterIP'), ('port', 8080), ('loadBalancerIP', 'nil')])), ('persistence', ordereddict([('enabled', True), ('storageClass', 'nfs-client'), ('accessMode', 'ReadWriteOnce'), ('size', '8Gi')])), ('resources', ordereddict()), ('nodeSelector', ordereddict()), ('tolerations', []), ('affinity', ordereddict())])
-
+    data_test = ordereddict([('image', ordereddict([('repository', 'nextcloud'), ('tag', '15.0.2-apache'), ('pullPolicy', 'IfNotPresent')])), ('nameOverride', ''), ('fullnameOverride', ''), ('replicaCount', 1), ('ingress', ordereddict([('enabled', True), ('annotations', ordereddict())])), ('nextcloud', ordereddict([('host', 'nextcloud.corp.justin-tech.com'), ('username', 'admin'), ('password', 'changeme')])), ('internalDatabase', ordereddict([('enabled', True), ('name', 'nextcloud')])), ('externalDatabase', ordereddict([('enabled', False), ('host', None), ('user', 'VAULT:/secret/testdata/user'), ('password', 'VAULT:/secret/{environment}/testdata/password'), ('database', 'nextcloud')])), ('mariadb', ordereddict([('enabled', True), ('db', ordereddict([('name', 'nextcloud'), ('user', 'nextcloud'), ('password', 'changeme')])), ('persistence', ordereddict([('enabled', True), ('storageClass', 'nfs-client'), ('accessMode', 'ReadWriteOnce'), ('size', '8Gi')]))])), ('service', ordereddict([('type', 'ClusterIP'), ('port', 8080), ('loadBalancerIP', 'nil')])), ('persistence', ordereddict([('enabled', True), ('storageClass', 'nfs-client'), ('accessMode', 'ReadWriteOnce'), ('size', '8Gi')])), ('resources', ordereddict()), ('nodeSelector', ordereddict()), ('tolerations', []), ('affinity', ordereddict())])
     yaml_file = "./tests/test.yaml"
     data = vault.load_yaml(yaml_file)
+    print(data)
     assert_equal(data, data_test)
 
 def test_git_path():
@@ -37,7 +37,7 @@ def filecheckfunc():
 
 def test_enc():
     os.environ["KVVERSION"] = "v2"
-    input_values = ["adfs1", "adfs2", "adfs3"]
+    input_values = ["adfs1", "adfs2", "adfs3", "adfs4"]
     output = []
 
     def mock_input(s):
@@ -51,6 +51,7 @@ def test_enc():
     assert output == [
         'Input a value for /nextcloud/password: ',
         'Input a value for /externalDatabase/user: ',
+        'Input a value for /externalDatabase/password: ',
         'Input a value for /mariadb/db/password: ',
     ]
 

--- a/tests/test_vault.py
+++ b/tests/test_vault.py
@@ -49,10 +49,30 @@ def test_enc():
     vault.main(['enc', './tests/test.yaml'])
 
     assert output == [
-        'Input a value for /nextcloud/password: ',
-        'Input a value for /externalDatabase/user: ',
-        'Input a value for /externalDatabase/password: ',
-        'Input a value for /mariadb/db/password: ',
+        'Input a value for nextcloud.password: ',
+        'Input a value for externalDatabase.user: ',
+        'Input a value for externalDatabase.password: ',
+        'Input a value for mariadb.db.password: ',
+    ]
+
+def test_enc_with_env():
+    os.environ["KVVERSION"] = "v2"
+    input_values = ["adfs1", "adfs2", "adfs3", "adfs4"]
+    output = []
+
+    def mock_input(s):
+        output.append(s)
+        return input_values.pop(0)
+    vault.input = mock_input
+    vault.print = lambda s : output.append(s)
+
+    vault.main(['enc', './tests/test.yaml', '-e', 'test'])
+
+    assert output == [
+        'Input a value for nextcloud.password: ',
+        'Input a value for externalDatabase.user: ',
+        'Input a value for externalDatabase.password: ',
+        'Input a value for mariadb.db.password: ',
     ]
 
 def test_refuse_enc_from_file_with_bad_name():
@@ -65,6 +85,14 @@ def test_enc_from_file():
     vault.main(['enc', './tests/test.yaml', '-s', './tests/test.yaml.dec'])
     assert True # If it reaches here without error then encoding was a success
     # TODO: Maybe test if the secret is correctly saved to vault
+
+
+def test_enc_from_file_with_environment():
+    os.environ["KVVERSION"] = "v2"
+    vault.main(['enc', './tests/test.yaml', '-s', './tests/test.yaml.dec', '-e', 'test'])
+    assert True # If it reaches here without error then encoding was a success
+    # TODO: Maybe test if the secret is correctly saved to vault
+
 
 def test_dec():
     os.environ["KVVERSION"] = "v2"

--- a/tests/test_vault.py
+++ b/tests/test_vault.py
@@ -1,21 +1,15 @@
 #!/usr/bin/env python3
 
-import pytest
-import src.vault as vault
-import ruamel.yaml
-import hvac
 import os
-import argparse
-from argparse import RawTextHelpFormatter
-import glob
-import sys
-import git
-import platform
-from datadiff.tools import assert_equal
-from collections import OrderedDict as ordereddict
-import mock
-from shutil import copyfile
 import subprocess
+from collections import OrderedDict as ordereddict
+from shutil import copyfile
+
+import pytest
+from datadiff.tools import assert_equal
+
+import src.vault as vault
+
 
 def test_load_yaml():
 


### PR DESCRIPTION
# Pull Request Template

## Description

Ok, so this is a first pass at modifying the encoder and decoder to be environment aware.  It seems to successfully inject an environment when passed, for example, using the `test.yaml` and a CLI flag of `-e local` will result in a mariadb password in Vault that is directly associated with the local environment 

```
❯ vault kv get secret/secret/helm/helm-vault/local/mariadb/db/password
====== Metadata ======
Key              Value
---              -----
created_time     2021-03-16T22:33:17.268843Z
deletion_time    n/a
destroyed        false
version          1

==== Data ====
Key      Value
---      -----
value    asdfto
```

While a similar encoding but sans `-e` would result in the following 

```
❯ vault kv get secret/secret/helm/helm-vault/mariadb/db/password
====== Metadata ======
Key              Value
---              -----
created_time     2021-03-16T22:32:10.503021Z
deletion_time    n/a
destroyed        false
version          1

==== Data ====
Key      Value
---      -----
value    tested
```

**HOWEVER** I am still pretty new to vault, and there is a concept I don't quite understand yet called the `VAULT_TEMPLATE_POSITION`.  In the `test.yaml` this snippet 

```yaml
externalDatabase:
  enabled: false

  ## Database host
  host:

  ## Database user
  user: VAULT:/secret/testdata/user
```

does not pick up the environment, and I _think_ 

```python
                if value.startswith(envs[VAULT_TEMPLATE_POSITION]):
                    _full_path = value[len(envs[VAULT_TEMPLATE_POSITION]):]
                else:
                    _full_path = None
```

is the culprit _but_ I'm still learning what this is so I'm not messing with it yet 😄 

Fixes # (issue)

#25 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

Currently this has only been verified manually

**Test Configuration**:
* Python Version: 3.9
* Vault Version: 1.6.3

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Mentions:

@Just-Insane
