### PR TITLE
Add support for Vault namespaces (used in Vault Enterprise)

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,12 @@ pip3 install -r ./tests/requirements.txt
 python3 -m pytest
 ```
 
+for running tests using docker, you can use the following command:
+
+```
+./run-test.sh
+```
+
 ### Other Tests
 
 Unittesting and integration testing is automatically run via Github Actions on commit and PRs.

--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ Decrypted files have the suffix ".yaml.dec" by default
 |--------------------|---------------------------|--------|--------|
 |`VAULT_ADDR`|`null`|The HTTP(S) address fo Vault|Yes|
 |`VAULT_TOKEN`|`null`|The token used to authenticate with Vault|Yes|
+|`VAULT_NAMESPACE`|`null`|The Vault namespace used for the command||
 |`VAULT_PATH`|`secret/helm`|The default path used within Vault||
 |`VAULT_MOUNT_POINT`|`secret`|The default mountpoint used within Vault||
 |`SECRET_DELIM`|`changeme`|The value which will be searched for within YAML to prompt for encryption/decryption||
@@ -210,6 +211,14 @@ Default when not set: `null`, the program will error and inform you that this ad
 The token used to authenticate with Vault.
 
 Default when not set: `null`, the program will error and inform you that this value needs to be set as an environment variable.
+</details>
+
+<details>
+<summary>VAULT_NAMESPACE</summary>
+
+The Vault namespace used for the command. Namespaces are isolated environments that functionally exist as "Vaults within a Vault." They have separate login paths and support creating and managing data isolated to their namespace. Namespaces are only available in Vault Enterprise.
+
+Default when not set: `null`.
 </details>
 
 <details>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: "3.5"
+services:
+  vault:
+    container_name: helm-vault
+    image: vault
+    ports:
+      - 8200:8200
+    environment:
+      VAULT_DEV_ROOT_TOKEN_ID: "802e831f-bf5e-2740-d1f1-bbd936140e0b"
+      SKIP_SETCAP: "true"
+      VAULT_ADDR: "http://localhost:8200"
+    healthcheck:
+      test: ["CMD", "vault", "status"]
+      interval: 2s
+      timeout: 3s
+      retries: 30

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+set -e
+
+export VAULT_ADDR="http://localhost:8200"
+export VAULT_TOKEN="802e831f-bf5e-2740-d1f1-bbd936140e0b"
+export KVVERSION="v2"
+
+docker compose up -d 
+function getContainerHealth {
+    docker inspect --format "{{json .State.Health.Status }}" $1
+}
+
+# check that vault is running
+while STATUS=$(getContainerHealth helm-vault); [ "$STATUS" != '"healthy"' ]; do
+    if [ -z "$STATUS" ]; then
+        echo "Failed to retrieve status of docker container helm-vault"
+        exit 1
+    fi
+    if [ "$STATUS" == '"unhealthy"' ]; then
+        echo "Failed to start container helm-vault. See docker logs for details."
+        exit 1
+    fi
+    printf '.'
+    sleep 1
+done
+printf $'\n'
+
+# install and run tests
+pip3 install -r ./tests/requirements.txt
+python3 -m pytest

--- a/src/vault.py
+++ b/src/vault.py
@@ -198,7 +198,7 @@ class Vault:
 
         # Setup Vault client (hvac)
         try:
-            self.client = hvac.Client(url=self.envs.vault_addr, token=os.environ["VAULT_TOKEN"])
+            self.client = hvac.Client(url=self.envs.vault_addr, namespace=os.environ["VAULT_NAMESPACE"], token=os.environ["VAULT_TOKEN"])
         except KeyError:
             print("Vault not configured correctly, check VAULT_ADDR and VAULT_TOKEN env variables.")
         except Exception as ex:

--- a/src/vault.py
+++ b/src/vault.py
@@ -198,7 +198,7 @@ class Vault:
 
         # Setup Vault client (hvac)
         try:
-            self.client = hvac.Client(url=self.envs.vault_addr, namespace=os.environ["VAULT_NAMESPACE"], token=os.environ["VAULT_TOKEN"])
+            self.client = hvac.Client(url=self.envs.vault_addr, namespace=os.environ.get("VAULT_NAMESPACE"), token=os.environ["VAULT_TOKEN"])
         except KeyError:
             print("Vault not configured correctly, check VAULT_ADDR and VAULT_TOKEN env variables.")
         except Exception as ex:


### PR DESCRIPTION
# Add support for Vault namespaces (used in Vault Enterprise)

## Description

This PR adds support Vault Enterprise namespaces. In accordance with `vault-cli` the Vault Namespace can be configured using the environment variable `VAULT_NAMESPACE`.

Also refer to: https://www.vaultproject.io/docs/commands#vault_namespace

Fixes #38 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Mentions:

@Just-Insane
