### PR TITLE
Pass thought return code of helm run as a exit code of plugin

### DIFF
--- a/src/vault.py
+++ b/src/vault.py
@@ -286,17 +286,13 @@ def cleanup(args, envs):
         os.remove(decode_file)
         if args.verbose is True:
             print(f"Deleted {decode_file}")
-            sys.exit()
     except AttributeError:
         for fl in glob.glob("*.dec"):
             os.remove(fl)
             if args.verbose is True:
                 print(f"Deleted {fl}")
-                sys.exit()
     except Exception as ex:
         print(f"Error: {ex}")
-    else:
-        sys.exit()
 
 # Get value from a nested hash structure given a path of key names
 # For example:
@@ -396,16 +392,24 @@ def main(argv=None):
             cmd = f"helm {args.action} {leftovers} -f {decode_file}"
             if args.verbose is True:
                 print(f"About to execute command: {cmd}")
-            subprocess.run(cmd, shell=True)
+            subprocess.run(cmd, shell=True, check=True)
+        except subprocess.CalledProcessError as ex:
+            cleanup(args, envs)
+            return ex.returncode
         except Exception as ex:
             print(f"Error: {ex}")
+            cleanup(args, envs)
+            return 1
 
         cleanup(args, envs)
 
+    return 0
+
 if __name__ == "__main__":
+    ret = 0
     try:
-        main()
+        ret = main()
     except Exception as ex:
         print(f"ERROR: {ex}")
-    except SystemExit:
-        pass
+        ret = 1
+    sys.exit(ret)

--- a/src/vault.py
+++ b/src/vault.py
@@ -395,21 +395,19 @@ def main(argv=None):
             subprocess.run(cmd, shell=True, check=True)
         except subprocess.CalledProcessError as ex:
             cleanup(args, envs)
-            return ex.returncode
+            sys.exit(ex.returncode)
         except Exception as ex:
             print(f"Error: {ex}")
             cleanup(args, envs)
-            return 1
 
         cleanup(args, envs)
 
     return 0
 
 if __name__ == "__main__":
-    ret = 0
     try:
-        ret = main()
+        main()
     except Exception as ex:
         print(f"ERROR: {ex}")
-        ret = 1
-    sys.exit(ret)
+    except SystemExit as ex:
+        sys.exit(ex.code)

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,4 +1,5 @@
 pytest
+nose
 datadiff
 mock
 pytest_mock


### PR DESCRIPTION
## Description

The plugin does not handle helm error. Helm vault lint exit code is always 0. This PR fix helm vault lint for CI/CD.

Fixes #46

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

**Test Configuration**:
* Python Version: 3.9.5
* Vault Version: 1.5.2

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Mentions:

@Just-Insane
